### PR TITLE
NYUP 1005 - Matomo Analytics and Google Analytics

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,32 +1,6 @@
-# old environment .env.prod
-
-# For deployment to web1.dlib.nyu.edu
-
-# NODE_ENV=production
-# VUE_APP_SOLR_HOST=discovery1.dlib.nyu.edu
-# VUE_APP_SOLR_PORT=443
-# VUE_APP_SOLR_PROTOCOL=https
-
-# variables to point at the API (by Alberto) that points to Solr
-# API also parses data and formats the data better for rendering
-# VITE_API_TO_SOLR_PROTOCOL=https
-# VITE_API_TO_SOLR_HOST=sites.dlib.nyu.edu/viewer/api/v1/search?index=open-square-metadata-v1
-# VITE_TITLE=.env.prod
-
-# TODO: remove in favor of matomo tracking
-# Uncomment this to include GA <script> code in <head> of index.html
-# Using the tracking ID for old Open Access Books site
-# See https://jira.nyu.edu/jira/browse/NYUP-552
-# VUE_APP_GOOGLE_ANALYTICS_TRACKING_ID=UA-51495518-1
-
-# old environmen .env.prod ^^^^
-
 # For deployment to web1.dlib.nyu.edu
 
 NODE_ENV=production
-# VUE_APP_SOLR_HOST=discovery1.dlib.nyu.edu
-# VUE_APP_SOLR_PORT=443
-# VUE_APP_SOLR_PROTOCOL=https
 
 # variables to point at the API (by Alberto) that points to Solr
 # API also parses data and formats the data better for rendering
@@ -34,8 +8,13 @@ VITE_API_TO_SOLR_PROTOCOL=https
 VITE_API_TO_SOLR_HOST=sites.dlib.nyu.edu/viewer/api/v1/search?index=open-square-metadata-v1
 VITE_TITLE=.env.production
 
-# TODO: remove in favor of matomo tracking
+# solr instance in stage for now
+VITE_SOLR_URL=https://stagediscovery.dlib.nyu.edu/solr/open-square-metadata-v1/select?
+
 # Uncomment this to include GA <script> code in <head> of index.html
 # Using the tracking ID for old Open Access Books site
 # See https://jira.nyu.edu/jira/browse/NYUP-552
-VUE_APP_GOOGLE_ANALYTICS_TRACKING_ID=UA-51495518-1
+VITE_GOOGLE_ANALYTICS_TRACKING_ID=G-6ZBRSG08EY
+
+# Matomo Analytics
+VITE_MATOMO_ANALYTICS_USER=nyulib.matomo.cloud

--- a/index.html
+++ b/index.html
@@ -12,6 +12,49 @@
     <link rel="stylesheet" href="https://opensquare.nyupress.org/css/style.css">
     <link rel="stylesheet" href="css/style.css">
 
+    <!-- google analytics -->
+    <script>
+        const googleanalytics = import.meta.env.VITE_GOOGLE_ANALYTICS_TRACKING_ID;
+        const isProd = import.meta.env.PROD;
+        if (isProd && googleanalytics){
+            const script = document.createElement("script");
+            script.src = `https://www.googletagmanager.com/gtag/js?id=${
+                googleanalytics
+            }`;
+            script.async = true;
+            document.head.appenChild(script);
+
+            const script2 = document.createElement("script");
+            script2.innerHTML = `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', ${googleanalytics}, { 'anonymize_ip': true });
+            `;
+            document.head.appendChild(script2);
+        }
+    </script>
+
+    <!-- matomo analytics -->
+    <script>
+        const matomoanalytics = import.meta.env.VITE_MATOMO_ANALYTICS_URL;
+        if (isProd && matomoanalytics){
+            var _paq = window._paq = window._paq || [];
+            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+                var u="https://" + matomoanalytics + "/";
+                _paq.push(['setTrackerUrl', u + 'matomo.php']);
+                _paq.push(['setSiteId', '18']);
+                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                g.async=true;
+                g.src="https://cdn.matomo.cloud/" + matomoanalytics + "/matomo.js";
+                s.parentNode.insertBefore(g,s);
+            })();
+        }
+    </script>
+
   </head>
 <body class="search-page">
     <div class="hold-all">


### PR DESCRIPTION
This PR will add the following:
- Matomo analytics ID in produciton environment
- Google analytics ID in production environment
- Conditional load for Matomo and Google analytics only in Production

Link to (NYUP1005)[https://jira.nyu.edu/browse/NYUP-1005]

To test this PR:
- check out this branch
- run `npm run build` for production build
- run `npm run preview` to serve the production build
- (notice matomo tag and google analytics tag in index.html)