### PR TITLE
Add initial Snyk baseline workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,55 @@
+name: Snyk
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+      - staging
+      - main
+  push:
+    branches:
+      - master
+      - develop
+      - staging
+      - main
+
+jobs:
+  open-source-security:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Snyk
+        if: ${{ env.SNYK_TOKEN != '' }}
+        uses: snyk/actions/setup@master
+
+      - name: Runtime dependency gate
+        if: ${{ env.SNYK_TOKEN != '' }}
+        run: snyk test --file=package.json --package-manager=npm --severity-threshold=high
+
+      - name: Dev dependency visibility
+        if: ${{ github.event_name == 'push' && env.SNYK_TOKEN != '' }}
+        continue-on-error: true
+        run: snyk test --file=package.json --package-manager=npm --dev --severity-threshold=high
+
+      - name: Monitor long-lived branches
+        if: ${{ github.event_name == 'push' && env.SNYK_TOKEN != '' }}
+        run: |
+          snyk monitor --file=package.json --package-manager=npm
+          snyk monitor --file=package.json --package-manager=npm --dev

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -19,15 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 20
           cache: npm
@@ -36,20 +34,24 @@ jobs:
         run: npm ci
 
       - name: Setup Snyk
-        if: ${{ env.SNYK_TOKEN != '' }}
-        uses: snyk/actions/setup@master
+        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04
 
       - name: Runtime dependency gate
-        if: ${{ env.SNYK_TOKEN != '' }}
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk test --file=package.json --package-manager=npm --severity-threshold=high
 
       - name: Dev dependency visibility
-        if: ${{ github.event_name == 'push' && env.SNYK_TOKEN != '' }}
+        if: ${{ github.event_name == 'push' }}
         continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk test --file=package.json --package-manager=npm --dev --severity-threshold=high
 
       - name: Monitor long-lived branches
-        if: ${{ github.event_name == 'push' && env.SNYK_TOKEN != '' }}
+        if: ${{ github.event_name == 'push' }}
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
           snyk monitor --file=package.json --package-manager=npm
           snyk monitor --file=package.json --package-manager=npm --dev

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -33,23 +33,40 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check Snyk token availability
+        id: snyk-token
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          if [ -n "$SNYK_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip Snyk
+        if: ${{ steps.snyk-token.outputs.available != 'true' }}
+        run: echo "SNYK_TOKEN is not configured; skipping Snyk checks."
+
       - name: Setup Snyk
+        if: ${{ steps.snyk-token.outputs.available == 'true' }}
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04
 
       - name: Runtime dependency gate
+        if: ${{ steps.snyk-token.outputs.available == 'true' }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk test --file=package.json --package-manager=npm --severity-threshold=high
 
       - name: Dev dependency visibility
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && steps.snyk-token.outputs.available == 'true' }}
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk test --file=package.json --package-manager=npm --dev --severity-threshold=high
 
       - name: Monitor long-lived branches
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && steps.snyk-token.outputs.available == 'true' }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+package-lock=true
+save-exact=true
+allow-git=none
+min-release-age=7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
-  "name": "vite-test-project-react",
-  "version": "0.0.0",
+  "name": "open-square-search-application",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-test-project-react",
-      "version": "0.0.0",
+      "name": "open-square-search-application",
+      "version": "2.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "sass": "^1.79.4"
+        "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.66",
@@ -21,6 +20,7 @@
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
+        "sass": "^1.79.4",
         "vite": "^5.2.0",
         "vitest": "^2.1.3"
       }
@@ -1717,6 +1717,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
       "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "dev": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -2802,7 +2803,8 @@
     "node_modules/immutable": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw=="
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -3786,6 +3788,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
       "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "dev": true,
       "engines": {
         "node": ">= 14.16.0"
       },
@@ -3982,6 +3985,7 @@
       "version": "1.79.4",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.4.tgz",
       "integrity": "sha512-K0QDSNPXgyqO4GZq2HO5Q70TLxTH6cIT59RdoCHMivrC8rqzaTw5ab9prjz9KUN1El4FLXrBXJhik61JR4HcGg==",
+      "dev": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^4.0.0",
@@ -4092,6 +4096,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
       "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5806,6 +5811,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
       "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "dev": true,
       "requires": {
         "readdirp": "^4.0.1"
       }
@@ -6608,7 +6614,8 @@
     "immutable": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw=="
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -7286,7 +7293,8 @@
     "readdirp": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA=="
+      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "dev": true
     },
     "reflect.getprototypeof": {
       "version": "1.0.6",
@@ -7409,6 +7417,7 @@
       "version": "1.79.4",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.4.tgz",
       "integrity": "sha512-K0QDSNPXgyqO4GZq2HO5Q70TLxTH6cIT59RdoCHMivrC8rqzaTw5ab9prjz9KUN1El4FLXrBXJhik61JR4HcGg==",
+      "dev": true,
       "requires": {
         "chokidar": "^4.0.0",
         "immutable": "^4.0.0",
@@ -7491,7 +7500,8 @@
     "source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "dev": true
     },
     "stackback": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "sass": "^1.79.4"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",
@@ -34,6 +33,7 @@
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
+    "sass": "^1.79.4",
     "vite": "^5.2.0",
     "vitest": "^2.1.3"
   }


### PR DESCRIPTION
### Summary:
- add a minimal GitHub Actions workflow to run Snyk on pull requests and long-lived branch pushes
- keep runtime dependency findings as the primary gate and dev dependency findings informational
- move sass to devDependencies so Snyk runtime results match the actual static S3 deployment model

Notes
- local runtime scan is clean after reclassifying sass
- the workflow expects a repository secret named SNYK_TOKEN
- Snyk Code is not included because it is not enabled in the current Snyk organization

Validation
- npm ci
- snyk test --file=package.json --package-manager=npm --severity-threshold=high